### PR TITLE
Fix: style.css still referenced deleted background.png

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,7 +8,7 @@ body, html {
     display: flex;
     justify-content: center;
     align-items: center;
-    background: url('images/background.png') center/cover no-repeat fixed;
+    background: url('images/background.webp') center/cover no-repeat fixed;
     transition: background-image 1s ease-in-out;
     overflow: hidden;
     position: fixed;


### PR DESCRIPTION
Bug found during Chrome extension offline testing — `style.css` line 11 still had `url('images/background.png')` which was deleted in #29. Changed to `background.webp`.