### PR TITLE
Reconcile version to 2.2.1 (repo was 2.0.3, live Store 2.2.0, identical code)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.2.1] - Repo/store version reconciliation
+- The published Web Store build was 2.2.0 while this repo was still tagged 2.0.3, though the code was **identical**. Advancing the repo to 2.2.1 so git is once again the source of truth and future releases publish cleanly.
+- NOTE: audio (background music + rain) still loads from remote third-party URLs (saavncdn/mixkit) and is the cause of the reported "sound not working" issue. A local-audio fix is pending licensed audio assets — see extension-ops KB §3.1. This release does NOT yet fix audio.
+
 All notable changes to the Geeta Quote Daily Chrome Extension will be documented in this file.
 
 ## [2.0.3] - 2024-03-20

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Geeta Quote Daily",
-  "version": "2.0.3",
+  "version": "2.2.1",
   "description": "Get daily wisdom from Bhagavad Gita with beautiful visuals and soothing music.",
   "author": "Rohit Wadhwa",
   "homepage_url": "https://in.linkedin.com/in/rohit-wadhwa",


### PR DESCRIPTION
The published Web Store build was **2.2.0** while this repo was still at **2.0.3** — but the code is byte-for-byte identical. This advances the repo to **2.2.1** so git is the source of truth again.

Note: audio still loads from remote saavncdn/mixkit URLs (the reported sound bug). Local-audio fix is tracked separately and is NOT in this PR.

Authored via extension-ops automation.