### PR TITLE
Fix music playback + dropdown styling + dynamic year (v2.3.1)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,6 @@ jobs:
             -x "*.git*" \
             -x "*.github*" \
             -x "node_modules/*" \
-            -x "audio/track-*.mp3" \
             -x "demo/*" \
             -x "newsletters/*" \
             -x "newsletters/**/*" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.3.1] - Music reliability + UI fixes
+- **Fixed "Play Music" not playing**: both tracks are now served locally (bundled) instead of streaming the 2nd track from GitHub raw, which was unreliable. Removed the `raw.githubusercontent.com` host permission (so no extra privacy justification needed).
+- Music button label now tracks the audio's real play/pause state (no more stuck "Play Music" while it buffers).
+- Restyled the track-selector dropdown to match the control buttons (was a plain dark box).
+- Copyright year in the footer is now dynamic (© 2024–current year).
+
 ## [2.2.1] - Repo/store version reconciliation
 - The published Web Store build was 2.2.0 while this repo was still tagged 2.0.3, though the code was **identical**. Advancing the repo to 2.2.1 so git is once again the source of truth and future releases publish cleanly.
 - NOTE: audio (background music + rain) still loads from remote third-party URLs (saavncdn/mixkit) and is the cause of the reported "sound not working" issue. A local-audio fix is pending licensed audio assets — see extension-ops KB §3.1. This release does NOT yet fix audio.

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
 
 <!-- Copyright notice -->
 <footer>
-    <p>© 2024 Geeta Quote Daily. All rights reserved.</p>
+    <p id="copyright">© 2024 Geeta Quote Daily. All rights reserved.</p>
 </footer>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Geeta Quote Daily",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Get daily wisdom from Bhagavad Gita with beautiful visuals and soothing music.",
   "author": "Rohit Wadhwa",
   "homepage_url": "https://in.linkedin.com/in/rohit-wadhwa",
@@ -11,11 +11,10 @@
   ],
   "host_permissions": [
     "https://assets.mixkit.co/*",
-    "https://vedicscriptures.github.io/*",
-    "https://raw.githubusercontent.com/*"
+    "https://vedicscriptures.github.io/*"
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self'; media-src 'self' https://assets.mixkit.co https://raw.githubusercontent.com; img-src 'self' https://img.buymeacoffee.com; style-src 'self' 'unsafe-inline';"
+    "extension_pages": "script-src 'self'; object-src 'self'; media-src 'self' https://assets.mixkit.co; img-src 'self' https://img.buymeacoffee.com; style-src 'self' 'unsafe-inline';"
   },
   "chrome_url_overrides": {
     "newtab": "index.html"

--- a/newtab.js
+++ b/newtab.js
@@ -64,10 +64,24 @@ function initializeElements() {
     elements.disableMusicUI = disableMusicUI;
     if (elements.backgroundMusic) elements.backgroundMusic.addEventListener('error', disableMusicUI, { once: true });
 
+    // Keep the music button label in sync with actual playback state (robust vs. play() promise timing)
+    if (elements.backgroundMusic) {
+        elements.backgroundMusic.addEventListener('play', () => { if (elements.musicToggleButton) elements.musicToggleButton.textContent = '🔇 Stop Music'; });
+        elements.backgroundMusic.addEventListener('pause', () => { if (elements.musicToggleButton) elements.musicToggleButton.textContent = '🔊 Play Music'; });
+        elements.backgroundMusic.addEventListener('ended', () => { if (elements.musicToggleButton) elements.musicToggleButton.textContent = '🔊 Play Music'; });
+    }
+
+    // Dynamic copyright year
+    try {
+        const cy = new Date().getFullYear();
+        const cp = document.getElementById('copyright');
+        if (cp) cp.textContent = '© 2024' + (cy > 2024 ? '–' + cy : '') + ' Geeta Quote Daily. All rights reserved.';
+    } catch (e) {}
+
     // Multi-track music: default bundled locally, extra tracks streamed from GitHub raw.
     const MUSIC_TRACKS = [
         { id: 'flute', name: 'Krishna Flute', url: 'audio/background-music.mp3' },
-        { id: 'hare-krishna', name: 'Hare Krishna Theme', url: 'https://raw.githubusercontent.com/rohit-wadhwa/geeta-quote-daily/main/audio/track-hare-krishna.mp3' }
+        { id: 'hare-krishna', name: 'Hare Krishna Theme', url: 'audio/track-hare-krishna.mp3' }
     ];
     elements.musicTrackSelect = document.getElementById('music-track');
     const applyMusicTrack = (id, autoplay) => {

--- a/style.css
+++ b/style.css
@@ -1244,13 +1244,21 @@ footer.visible {
 
 /* Music track selector (multi-track) */
 .music-track-select {
-    background: rgba(0, 0, 0, 0.35);
+    padding: 6px 28px 6px 12px;
+    font-size: 13px;
     color: #fff;
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    border-radius: 6px;
-    padding: 4px 8px;
-    font-size: 14px;
+    background-color: rgba(30, 30, 40, 0.55);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 4px;
     cursor: pointer;
-    margin-left: 4px;
+    min-height: 32px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    -webkit-appearance: none;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath fill='%23fff' d='M0 0l5 6 5-6z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    transition: all 0.2s ease;
 }
+.music-track-select:hover { opacity: 0.9; }
 .music-track-select option { color: #000; }


### PR DESCRIPTION
Fixes reported on the live site.

- **Play Music was silent**: the 2nd track streamed from GitHub raw, which stalled on load. Both tracks are now **bundled locally** (reliable, offline). Removed the `raw.githubusercontent.com` host permission -> no extra Privacy-practices justification needed to publish.
- **Button stuck on "Play Music"**: label now follows the audio elements real play/pause/ended events.
- **Odd dropdown**: track selector restyled to match the control buttons (rounded, dark glass, custom caret).
- **Dynamic year**: footer now shows © 2024–<current year>.

Merging this updates the Vercel site automatically. Version -> 2.3.1.

Tested via Chrome automation: files serve correctly (206/ranges); switching both tracks to local removes the streaming stall.