### PR TITLE
Fix: music button disappearing + no audio (v2.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.3.2] - Music button + playback fixes
+- **Fixed the music button disappearing** when you press Stop or switch tracks: the old "graceful fallback" hid the button on any play hiccup. It now stays put and just resets its label.
+- **Fixed no-audio**: removed a leftover `<source>` child that conflicted with the dynamically-set track URL (the media element wasn't fetching the file). Play now forces a `load()` when needed.
+
 ## [2.3.1] - Music reliability + UI fixes
 - **Fixed "Play Music" not playing**: both tracks are now served locally (bundled) instead of streaming the 2nd track from GitHub raw, which was unreliable. Removed the `raw.githubusercontent.com` host permission (so no extra privacy justification needed).
 - Music button label now tracks the audio's real play/pause state (no more stuck "Play Music" while it buffers).

--- a/index.html
+++ b/index.html
@@ -59,8 +59,7 @@
     <span>You are offline</span>
 </div>
 
-<audio id="background-music" loop preload="none" loading="lazy">
-    <source src="audio/background-music.mp3" type="audio/mpeg">
+<audio id="background-music" loop preload="none">
     Your browser does not support the audio element.
 </audio>
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Geeta Quote Daily",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Get daily wisdom from Bhagavad Gita with beautiful visuals and soothing music.",
   "author": "Rohit Wadhwa",
   "homepage_url": "https://in.linkedin.com/in/rohit-wadhwa",

--- a/newtab.js
+++ b/newtab.js
@@ -60,7 +60,7 @@ function initializeElements() {
 
     // Graceful audio fallback: if an audio file can't load/play, hide its control
     // instead of leaving a dead button (music is optional; quote + visuals still work).
-    const disableMusicUI = () => { if (elements.musicToggleButton) elements.musicToggleButton.style.display = 'none'; };
+    const disableMusicUI = () => { if (elements.musicToggleButton) elements.musicToggleButton.textContent = '🔊 Play Music'; }; // never hide; just reset label
     elements.disableMusicUI = disableMusicUI;
     if (elements.backgroundMusic) elements.backgroundMusic.addEventListener('error', disableMusicUI, { once: true });
 
@@ -1186,13 +1186,12 @@ const eventHandlers = {
     
     handleMusicToggle: () => {
         if (!elements.backgroundMusic) return;
-        if (elements.backgroundMusic.paused) {
-            elements.backgroundMusic.play().then(() => {
-                elements.musicToggleButton.textContent = '🔇 Stop Music';
-            }).catch(() => { if (elements.disableMusicUI) elements.disableMusicUI(); });
+        const a = elements.backgroundMusic;
+        if (a.paused) {
+            if (a.readyState < 2) { try { a.load(); } catch (e) {} }   // ensure the file actually fetches
+            a.play().catch(() => { if (elements.musicToggleButton) elements.musicToggleButton.textContent = '🔊 Play Music'; });
         } else {
-            elements.backgroundMusic.pause();
-            elements.musicToggleButton.textContent = '🔊 Play Music';
+            a.pause();
         }
     },
     


### PR DESCRIPTION
Fixes the two bugs reported on the live site:

1. **Button disappears on Stop / track switch** — the graceful-fallback code hid the music button (`display:none`) whenever play() hiccuped. It now **never hides**; it only resets the label. Play/pause events keep the label correct.
2. **No audio** — a leftover `<source src=audio/background-music.mp3>` child in the `<audio>` conflicted with the track URL set from JS, so the element never fetched the file (networkState stayed IDLE). Removed the source child; play now forces `load()` when not ready.

Kept `preload=none` so the audio only downloads when the user actually presses Play (good for a new-tab page).

Note: I could not fully verify audio *playback* via browser automation (the debugger suppresses media network loads), so please confirm on this PRs Vercel preview. The button-visibility fix is DOM-level and reliable. Version -> 2.3.2.